### PR TITLE
Enable clinical notes import from Apple Health

### DIFF
--- a/iOS/EirViewer/EirViewer.entitlements
+++ b/iOS/EirViewer/EirViewer.entitlements
@@ -5,7 +5,9 @@
 	<key>com.apple.developer.healthkit</key>
 	<true/>
 	<key>com.apple.developer.healthkit.access</key>
-	<array/>
+	<array>
+		<string>health-records</string>
+	</array>
 	<key>com.apple.developer.kernel.increased-memory-limit</key>
 	<true/>
 </dict>

--- a/iOS/EirViewer/Info.plist
+++ b/iOS/EirViewer/Info.plist
@@ -93,6 +93,8 @@
 	</array>
 	<key>NSHealthShareUsageDescription</key>
 	<string>Eir imports your health data (vitals, activity, lab values) from Apple Health to display alongside your medical records.</string>
+	<key>NSHealthClinicalHealthRecordsShareUsageDescription</key>
+	<string>Eir imports your clinical notes and health records from Apple Health to display alongside your other medical data.</string>
 	<key>NSHealthUpdateUsageDescription</key>
 	<string>Eir does not write any data to Apple Health. This permission is required by the HealthKit framework.</string>
 	<key>EIRBillingSubscriptionProductID</key>

--- a/iOS/EirViewer/Package.resolved
+++ b/iOS/EirViewer/Package.resolved
@@ -1,12 +1,92 @@
 {
   "pins" : [
     {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift",
+      "state" : {
+        "revision" : "6ba4827fb82c97d012eec9ab4b2de21f85c3b33d",
+        "version" : "0.30.6"
+      }
+    },
+    {
+      "identity" : "mlx-swift-lm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift-lm",
+      "state" : {
+        "revision" : "e33eba8513595bde535719c48fedcb10ade5af57"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "9f542610331815e29cc3821d3b6f488db8715517",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "bb4ba815dab96d4edc1e0b86d7b9acf9ff973a84",
+        "version" : "4.3.1"
+      }
+    },
+    {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
+        "version" : "2.3.5"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers",
+      "state" : {
+        "revision" : "150169bfba0889c229a2ce7494cf8949f18e6906",
+        "version" : "1.1.9"
+      }
+    },
+    {
       "identity" : "yams",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
         "revision" : "3d6871d5b4a5cd519adf233fbb576e0a2af71c17",
         "version" : "5.4.0"
+      }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
       }
     }
   ],

--- a/iOS/EirViewer/Sources/EirViewer/Services/ClinicalNoteFHIRExtractor.swift
+++ b/iOS/EirViewer/Sources/EirViewer/Services/ClinicalNoteFHIRExtractor.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PDFKit
 
 struct ClinicalNoteFHIRExtraction: Equatable {
     let summary: String
@@ -53,17 +54,38 @@ enum ClinicalNoteFHIRExtractor {
 
     private static func clinicalSummary(from resourceObject: [String: Any], fallbackTitle: String) -> String {
         let trimmedFallback = fallbackTitle.trimmingCharacters(in: .whitespacesAndNewlines)
-        let candidates: [String?] = [
+
+        // Get the note type (e.g., "Progress Notes", "Patient Instructions")
+        let noteType: String = [
             stringValue(resourceObject["title"]),
             stringValue(resourceObject["description"]),
             nestedString(resourceObject, path: ["type", "text"]),
             nestedString(resourceObject, path: ["code", "text"]),
             trimmedFallback
         ]
+        .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .first(where: { !$0.isEmpty }) ?? "Klinisk anteckning"
 
-        return candidates
-            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .first(where: { !$0.isEmpty }) ?? "Klinisk anteckning"
+        // Get the encounter type (e.g., "Office Visit", "Video Visit - MH/BH")
+        let encounter = (resourceObject["context"] as? [String: Any])
+            .flatMap { $0["encounter"] as? [[String: Any]] }?
+            .first
+            .flatMap { stringValue($0["display"]) }
+
+        // Get the primary author
+        let author = (resourceObject["author"] as? [[String: Any]])?
+            .first
+            .flatMap { stringValue($0["display"]) }
+
+        // Build a richer summary: "Progress Notes — Office Visit (Jennifer M Rodriguez, MD)"
+        var parts = [noteType]
+        if let encounter, !encounter.isEmpty {
+            parts.append(encounter)
+        }
+        if let author, !author.isEmpty {
+            return parts.joined(separator: " — ") + " (\(author))"
+        }
+        return parts.joined(separator: " — ")
     }
 
     private static func metadataLines(
@@ -71,28 +93,90 @@ enum ClinicalNoteFHIRExtractor {
         fallbackResourceType: String?,
         fallbackIdentifier: String?
     ) -> [String] {
-        var lines: [String] = ["Importerad från Apple Health"]
-
-        if let resourceType = resourceObject.flatMap(resourceType(from:)) ?? fallbackResourceType,
-           !resourceType.isEmpty {
-            lines.append("FHIR-resurs: \(resourceType)")
+        guard let obj = resourceObject else {
+            var lines = ["Importerad från Apple Health"]
+            if let rt = fallbackResourceType, !rt.isEmpty { lines.append("FHIR-resurs: \(rt)") }
+            if let id = fallbackIdentifier, !id.isEmpty { lines.append("FHIR-ID: \(id)") }
+            return lines
         }
 
-        if let identifier = resourceObject.flatMap({ stringValue($0["id"]) }) ?? fallbackIdentifier,
-           !identifier.isEmpty {
-            lines.append("FHIR-ID: \(identifier)")
+        var lines: [String] = []
+
+        // Author(s)
+        if let authors = obj["author"] as? [[String: Any]] {
+            let names = authors.compactMap { stringValue($0["display"]) }
+            if !names.isEmpty {
+                lines.append("Författare: \(names.joined(separator: ", "))")
+            }
         }
 
-        if let status = resourceObject.flatMap({ stringValue($0["status"]) }), !status.isEmpty {
+        // Authenticator (signing provider)
+        if let auth = obj["authenticator"] as? [String: Any],
+           let authName = stringValue(auth["display"]) {
+            // Only add if different from author
+            let authorNames = (obj["author"] as? [[String: Any]])?
+                .compactMap { stringValue($0["display"]) } ?? []
+            if !authorNames.contains(authName) {
+                lines.append("Signerad av: \(authName)")
+            }
+        }
+
+        // Encounter type
+        if let context = obj["context"] as? [String: Any] {
+            if let encounters = context["encounter"] as? [[String: Any]],
+               let encounterDisplay = encounters.first.flatMap({ stringValue($0["display"]) }),
+               !encounterDisplay.isEmpty {
+                lines.append("Besökstyp: \(encounterDisplay)")
+            }
+
+            // Provider type / specialty from context extension
+            if let extensions = context["extension"] as? [[String: Any]] {
+                for ext in extensions {
+                    if let concept = ext["valueCodeableConcept"] as? [String: Any],
+                       let text = stringValue(concept["text"]),
+                       !text.isEmpty {
+                        lines.append("Yrkesroll: \(text)")
+                    }
+                }
+            }
+
+            // Visit date from context.period
+            if let period = context["period"] as? [String: Any],
+               let start = stringValue(period["start"]),
+               !start.isEmpty {
+                lines.append("Besöksdatum: \(formatFHIRDate(start))")
+            }
+        }
+
+        // Document status
+        if let docStatus = stringValue(obj["docStatus"]), !docStatus.isEmpty {
+            lines.append("Dokumentstatus: \(docStatus)")
+        } else if let status = stringValue(obj["status"]), !status.isEmpty {
             lines.append("Status: \(status)")
         }
 
-        if let date = resourceObject.flatMap({ stringValue($0["date"]) ?? stringValue($0["created"]) }),
+        // Document date
+        if let date = stringValue(obj["date"]) ?? stringValue(obj["created"]),
            !date.isEmpty {
-            lines.append("Dokumentdatum: \(date)")
+            lines.append("Dokumentdatum: \(formatFHIRDate(date))")
         }
 
+        lines.append("Importerad från Apple Health")
+
         return lines
+    }
+
+    private static func formatFHIRDate(_ dateString: String) -> String {
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime]
+        if let date = isoFormatter.date(from: dateString) {
+            let formatter = DateFormatter()
+            formatter.dateStyle = .long
+            formatter.timeStyle = .short
+            formatter.locale = Locale(identifier: "sv_SE")
+            return formatter.string(from: date)
+        }
+        return dateString
     }
 
     private static func clinicalNoteBlocks(from object: [String: Any]) -> [String] {
@@ -187,6 +271,8 @@ enum ClinicalNoteFHIRExtractor {
         let body: String?
         if contentType.contains("html") || contentType.contains("xml") || contentType.contains("xhtml") {
             body = plainText(fromMarkupData: data)
+        } else if contentType.contains("pdf") {
+            body = extractTextFromPDF(data: data)
         } else if contentType.contains("text") || contentType.isEmpty {
             body = String(data: data, encoding: .utf8)
         } else {
@@ -258,6 +344,18 @@ enum ClinicalNoteFHIRExtractor {
 
     private static func plainText(fromMarkupData data: Data) -> String? {
         return stripHTML(from: String(decoding: data, as: UTF8.self))
+    }
+
+    private static func extractTextFromPDF(data: Data) -> String? {
+        guard let document = PDFDocument(data: data) else { return nil }
+        var pages: [String] = []
+        for i in 0..<document.pageCount {
+            if let page = document.page(at: i), let text = page.string, !text.isEmpty {
+                pages.append(text)
+            }
+        }
+        let result = pages.joined(separator: "\n\n")
+        return result.isEmpty ? nil : result
     }
 
     private static func stripHTML(from html: String) -> String {

--- a/iOS/EirViewer/Sources/EirViewer/Services/HealthKitToEirConverter.swift
+++ b/iOS/EirViewer/Sources/EirViewer/Services/HealthKitToEirConverter.swift
@@ -138,6 +138,8 @@ struct HealthKitToEirConverter {
         let details: String
         var notes: [String]? = nil
         var tags = ["apple-health", category.rawValue.lowercased()]
+        var provider = EirProvider(name: "Apple Health", region: nil, location: nil)
+        var responsiblePerson: EirResponsiblePerson? = nil
 
         switch category {
         case .bloodPressure:
@@ -197,6 +199,26 @@ struct HealthKitToEirConverter {
             notes = extracted.noteBlocks.isEmpty ? nil : extracted.noteBlocks
             tags += extracted.tags
 
+            // Extract provider and author from FHIR JSON
+            if let data = record.fhirResource?.data,
+               let fhirObj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                if let authors = fhirObj["author"] as? [[String: Any]],
+                   let authorName = authors.first.flatMap({ $0["display"] as? String }) {
+                    // Extract role from context extension
+                    let role = (fhirObj["context"] as? [String: Any])
+                        .flatMap { $0["extension"] as? [[String: Any]] }?
+                        .compactMap { ($0["valueCodeableConcept"] as? [String: Any])?["text"] as? String }
+                        .first
+                    responsiblePerson = EirResponsiblePerson(name: authorName, role: role)
+                }
+                // Use encounter display as provider name if available
+                if let context = fhirObj["context"] as? [String: Any],
+                   let encounters = context["encounter"] as? [[String: Any]],
+                   let encounterDisplay = encounters.first?["display"] as? String {
+                    provider = EirProvider(name: encounterDisplay, region: nil, location: nil)
+                }
+            }
+
         default:
             guard let quantitySample = sample as? HKQuantitySample,
                   let unit = category.hkUnit else { return nil }
@@ -212,9 +234,9 @@ struct HealthKitToEirConverter {
             time: timeStr,
             category: category.eirCategory,
             type: category.rawValue,
-            provider: EirProvider(name: "Apple Health", region: nil, location: nil),
+            provider: provider,
             status: nil,
-            responsiblePerson: nil,
+            responsiblePerson: responsiblePerson,
             content: EirContent(summary: summary, details: details, notes: notes),
             attachments: nil,
             tags: Array(Set(tags)).sorted()


### PR DESCRIPTION
## Summary
- Adds `health-records` entitlement and `NSHealthClinicalHealthRecordsShareUsageDescription` to enable `HKClinicalRecord` access
- Extracts rich metadata from Epic FHIR DocumentReference resources (author, encounter type, provider role, visit date, document status)
- Adds PDF text extraction via PDFKit for inline FHIR attachments
- Populates `responsiblePerson` and `provider` fields on clinical note entries from FHIR author/encounter data

## HealthKit clinical notes limitation

**The actual clinical note content (text/html, text/rtf) is NOT accessible via HealthKit.**

Testing on a real device with Epic/MyChart health records confirmed that FHIR DocumentReference resources from HealthKit contain only URL references to Binary resources (e.g., `Binary/eSxovuCBBj65...`), not inline base64 data. The Apple Health app can display these documents because it holds OAuth tokens from the provider connection internally — but it does not expose those tokens or provide any API for third-party apps to fetch the referenced Binary content.

This means every clinical note entry will have structured metadata (author, date, encounter type, specialty) but no note body text. This is a known limitation that affects all third-party apps using `HKClinicalRecord`.

### Possible future approach: direct SMART on FHIR integration
To access the actual document content, we would need to register as a SMART on FHIR client and authenticate directly with Epic's patient FHIR API, bypassing HealthKit entirely. This would give full access to the Binary resources but requires a separate OAuth flow.

## Test plan
- [ ] Build and run on physical iPhone with iOS 17+
- [ ] Navigate to Apple Health import, verify "Kliniska anteckningar" category appears
- [ ] Import clinical notes, verify authorization prompt includes clinical records
- [ ] Verify imported entries show author, encounter type, visit date in metadata
- [ ] Verify entries with no inline content still display correctly with metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)